### PR TITLE
Update apt commands

### DIFF
--- a/ChainLinkDevSetup.md
+++ b/ChainLinkDevSetup.md
@@ -3,7 +3,11 @@
 ## Install required packages
 
 ```script
-sudo apt install build-essential git libssl1.0-dev libssl-dev libxml2-dev libxslt1-dev postgresql-9.6 libpq-dev nodejs
+# Ensure that your system is up to date and fully patched
+sudo apt update -y && sudo apt upgrade -y
+
+# Install dependencies
+sudo apt -y install build-essential git libssl1.0-dev libssl-dev libxml2-dev libxslt1-dev postgresql-9.6 libpq-dev nodejs
 ```
 
 ## Set up Ruby


### PR DESCRIPTION
This PR will add `apt update` and `apt upgrade` to ensure the system is already updated.

Also added the `-y` flag so commands can be copy-pasted without having to do anything else, but can be removed if you disagree.