### PR TITLE
Expost ports of docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ It will ask if you're ready to print coordinator credentials to the screen. You 
 And finally run this to actually start the node:
 
 ```shell
-docker run -t --env-file=.env smartcontract/chainlink
+docker run -t -p 6688:6688 --env-file=.env smartcontract/chainlink
 ```
 
 Test connection (should be up to date with current Ethereum block):


### PR DESCRIPTION
Connection will be refused if you don't use -p 6688:6688 to expose ports of the docker container.